### PR TITLE
videodecoder: Fix memory leak

### DIFF
--- a/gst-libs/gst/video/gstvideodecoder.c
+++ b/gst-libs/gst/video/gstvideodecoder.c
@@ -3062,7 +3062,7 @@ foreach_metadata (GstBuffer * inbuf, GstMeta ** meta, gpointer user_data)
     if (G_UNLIKELY (buffer)) {
       if (frame->abidata.ABI.meta_buffer == NULL)
         frame->abidata.ABI.meta_buffer = gst_buffer_new ();
-      buffer = frame->abidata.ABI.meta_buffer = gst_buffer_new ();
+      buffer = frame->abidata.ABI.meta_buffer;
     }
 
     info->transform_func (buffer, *meta, inbuf, _gst_meta_transform_copy,


### PR DESCRIPTION
Avoid buffer allocation twice to copy metadata.

Upstream Status: Not Required
Signed-off-by: Bala Sai Kosuri <balasaik@xilinx.com>